### PR TITLE
results are missed when you modify the results during the batch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 doc/
 pkg/
 Gemfile.lock
+/.idea

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,13 @@
 ### 0.3.0 / 2011-05-16
 
+* Changed implementation of {DataMapper::ChunkedQuery::Chunks#each} to use the same sql queries as active record
+  find_each.
+* Removed {DataMapper::ChunkedQuery::Chunks#[]}, {DataMapper::ChunkedQuery::Chunks#at} and
+  {DataMapper::ChunkedQuery::Chunks#first}, because they can't be realized with the new
+  {DataMapper::ChunkedQuery::Chunks#each} implementation.
+
+### 0.3.0 / 2011-05-16
+
 * Added {DataMapper::ChunkedQuery::Mixin#each_slice} which calls
   {DataMapper::ChunkedQuery::Mixin#each_chunk}.
 * Added {DataMapper::ChunkedQuery::Mixin#batch}.

--- a/Gemfile
+++ b/Gemfile
@@ -83,7 +83,7 @@
 source :rubygems
 
 DATAMAPPER = 'http://github.com/datamapper'
-DM_VERSION = '~> 1.0'
+DM_VERSION = '~> 1.1'
 DO_VERSION = '~> 0.10.2'
 DM_DO_ADAPTERS = %w[sqlite postgres mysql oracle sqlserver]
 RAILS = 'http://github.com/rails/rails.git'

--- a/Gemfile
+++ b/Gemfile
@@ -97,6 +97,7 @@ else
 end
 
 gem 'dm-core',	DM_VERSION
+gem 'dm-aggregates',	DM_VERSION
 
 group :development do
   gem 'rake',		    '~> 0.8.7'

--- a/Gemfile
+++ b/Gemfile
@@ -96,7 +96,7 @@ else
   gem 'i18n',           '~> 0.5.0'
 end
 
-gem 'dm-core',	DM_VERSION, :git => "#{DATAMAPPER}/dm-core.git"
+gem 'dm-core',	DM_VERSION
 
 group :development do
   gem 'rake',		    '~> 0.8.7'
@@ -126,17 +126,17 @@ group :datamapper do
       gem "do_#{adapter}", DO_VERSION, options.dup
     end
 
-    gem 'dm-do-adapter', DM_VERSION, :git => "#{DATAMAPPER}/dm-do-adapter.git"
+    gem 'dm-do-adapter', DM_VERSION
   end
 
   adapters.each do |adapter|
-    gem "dm-#{adapter}-adapter", DM_VERSION, :git => "#{DATAMAPPER}/dm-#{adapter}-adapter.git"
+    gem "dm-#{adapter}-adapter", DM_VERSION
   end
 
   plugins = ENV['PLUGINS'] || ENV['PLUGIN']
   plugins = plugins.to_s.tr(',', ' ').split.push('dm-migrations').uniq
 
   plugins.each do |plugin|
-    gem plugin, DM_VERSION, :git => "#{DATAMAPPER}/#{plugin}.git"
+    gem plugin, DM_VERSION
   end
 end

--- a/gemspec.yml
+++ b/gemspec.yml
@@ -1,5 +1,5 @@
 name: dm-chunked_query
-version: 0.3.0
+version: 0.3.1
 summary: Allows performing chunked queries with DataMapper.
 description:
   Allows performing chunked queries on DataMapper Models or Collections.

--- a/lib/dm-chunked_query/chunks.rb
+++ b/lib/dm-chunked_query/chunks.rb
@@ -35,62 +35,6 @@ module DataMapper
       end
 
       #
-      # Provides random access to chunks.
-      #
-      # @param [Range<Integer>, Integer] key
-      #   The index or range of indices to access.
-      #
-      # @return [DataMapper::Collection]
-      #   A collection of resources at the given index or indices.
-      #
-      def [](key)
-        case key
-          when Range
-            index = key.first
-            span = key.to_a.size
-
-            chunk_at(index, span)
-          when Integer
-            chunk_at(key)
-        end
-      end
-
-      #
-      # Accesses a chunk at a specific index.
-      #
-      # @param [#to_i] index
-      #   The index to access.
-      #
-      # @return [DataMapper::Collection]
-      #   The chunk of resources at the given index.
-      #
-      def at(index)
-        chunk_at(index.to_i)
-      end
-
-      #
-      # Returns the first chunk(s).
-      #
-      # @param [Integer] n
-      #   The number of sub-chunks to include.
-      #
-      # @return [DataMapper::Collection]
-      #   The first chunk of resources.
-      #
-      # @raise [ArgumentError]
-      #   The number of sub-chunks was negative.
-      #
-      # @since 0.2.0
-      #
-      def first(n=1)
-        if n >= 0
-          chunk_at(0, n)
-        else
-          raise(ArgumentError, "negative array size")
-        end
-      end
-
-      #
       # Enumerates over each chunk in the collection of Chunks.
       #
       # @yield [chunk]
@@ -105,8 +49,19 @@ module DataMapper
       def each
         return enum_for(:each) unless block_given?
 
-        length.times do |index|
-          yield chunk_at(index)
+        relation = @query.all(batch_order).all(:limit => @per_chunk)
+        records = relation.all(primary_key.name.gte => 0)
+
+        while records.any?
+          yield records
+
+          break if records.size < @per_chunk
+
+          if primary_key_offset = records.last.key.first
+            records = relation.all(primary_key.name.gt => primary_key_offset)
+          else
+            raise "Primary key not included in the custom select clause"
+          end
         end
 
         return self
@@ -136,24 +91,12 @@ module DataMapper
 
       protected
 
-      #
-      # Creates a chunk of resources.
-      #
-      # @param [Integer] index
-      #   The index of the chunk.
-      #
-      # @param [Integer] span
-      #   The number of chunks the chunk should span.
-      #
-      # @return [DataMapper::Collection]
-      #   The collection of resources that makes up the chunk.
-      #
-      def chunk_at(index, span=1)
-        @query.all(batch_order)[(index * @per_chunk), (span * @per_chunk)]
-      end
-
       def batch_order
         @query.all(:order => @query.key).query
+      end
+
+      def primary_key
+        @query.key.first
       end
 
     end


### PR DESCRIPTION
Hi,

First off, thank you very much for this great extension to data mapper.  Its exactly what I needed.  

I found a bug though when during the batch you also modify the results in the batch.  For example, if you have a model with a name String.  If you batch query all of the instances where the name is nil and in the block you set the name to a value and save the model, then the batch query will only find about half of the results.

The active record guys have a different solution that uses ordering by the id and querying in each iteration ids greater than the last result's id.  Basically, I just copied their implementation in batches.rb and modified it to work with DataMapper.

There are a few consequences of this implementation.  The caller can't specify the order.  The model must have a single Serial property as its primary key.  Finally I couldn't implement the [], at and first methods so I deleted them (I didn't put much thought into it though, so maybe there is a way).

I'm sorry I didn't write any tests for this.  If I get around to it, I'll send you another pull request.

Thanks again for your work on this project.  I really appreciate it.

Best Regards,
Austin
